### PR TITLE
feat: add Sector and DeliveryJob

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2")                         // test db
+    testImplementation("org.orbisgis:h2gis:2.2.1")                  // h2 공간 연산 관련
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/com/loadingking/loading_king/core/logistics/domain/DeliveryJob.java
+++ b/src/main/java/com/loadingking/loading_king/core/logistics/domain/DeliveryJob.java
@@ -1,0 +1,57 @@
+package com.loadingking.loading_king.core.logistics.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name="delivery_jobs")
+public class DeliveryJob {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="job_id")
+    private Long id;
+
+    /*
+     * TODO: 해당 부분 추가 확인 필요
+     * UC-02의 3번 - 시스템은 변환된 좌표가 기사의 설정된 섹터 중 어디에 포함되는지 공간 연산으로 확인
+     * 실패시 "구역 외 지역(미배정)" 경고를 띄워 기사가 별도로 분류하게 한다
+     * 부분에서 미배정된 부분을 기사가 선택하게 하려면 기사 기반 미배정된 섹터를 조회하게 해야 함
+     */
+    @Column(name="driver_id", nullable = false)
+    private Long driverId;
+
+    @ElementCollection
+    @CollectionTable(name = "job_sectors", joinColumns = @JoinColumn(name = "job_id"))
+    private List<Long> sectorId;
+
+    @Column(name="work_date", nullable = false)
+    private LocalDate workDate;
+
+    @Enumerated(EnumType.STRING)
+    private JobStatus status;
+
+    protected DeliveryJob() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getDriverId() {
+        return driverId;
+    }
+
+    public List<Long> getSectorId() {
+        return sectorId;
+    }
+
+    public LocalDate getWorkDate() {
+        return workDate;
+    }
+
+    public JobStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/loadingking/loading_king/core/logistics/domain/DeliveryJobRepository.java
+++ b/src/main/java/com/loadingking/loading_king/core/logistics/domain/DeliveryJobRepository.java
@@ -1,0 +1,13 @@
+package com.loadingking.loading_king.core.logistics.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DeliveryJobRepository extends JpaRepository<DeliveryJob, Long> {
+
+    Optional<DeliveryJob> findActiveJobByDriverId(Long driverId);
+
+}

--- a/src/main/java/com/loadingking/loading_king/core/logistics/domain/JobStatus.java
+++ b/src/main/java/com/loadingking/loading_king/core/logistics/domain/JobStatus.java
@@ -1,0 +1,19 @@
+package com.loadingking.loading_king.core.logistics.domain;
+
+public enum JobStatus {
+    PENDING("대기"),
+    IN_PROGRESS("진행 중"),
+    COMPLETED("완료"),
+    CANCELLED("취소됨");
+
+    private final String description;
+
+    JobStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/src/main/java/com/loadingking/loading_king/core/sector/api/SectorController.java
+++ b/src/main/java/com/loadingking/loading_king/core/sector/api/SectorController.java
@@ -1,4 +1,37 @@
 package com.loadingking.loading_king.core.sector.api;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/sectors")
 public class SectorController {
+
+    @PostMapping
+    public ResponseEntity<Void> saveSectorByPoint(@RequestParam double lat, @RequestParam double lng) {
+        //TODO: 프론트에서 지도에 다각형을 그리면 그 좌표들을 서버에 저장
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/{driverId}")
+    public ResponseEntity<List<?>> getAllSectors(@PathVariable Long driverId) {
+        //TODO: 저장된 모든 구역의 경계 좌표와 이름을 목록으로 가져옴
+        return ResponseEntity.ok(List.of());
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> findSectorByPoint(@RequestParam double lat, @RequestParam double lng) {
+        //TODO: 특정 위도/경도를 보내면, 그 위치를 감싸고 있는 구역 정보를 응답
+        return ResponseEntity.ok(null);
+    }
+
+    @PostMapping("/assignment")
+    public ResponseEntity<?> assignSector() {
+        //TODO: 배송 업무 ID를 보내면, 각 업무의 위치 정보를 계산해서 적절한 구역 ID를 반환
+        return ResponseEntity.ok(null);
+    }
+
 }

--- a/src/main/java/com/loadingking/loading_king/core/sector/application/SectorService.java
+++ b/src/main/java/com/loadingking/loading_king/core/sector/application/SectorService.java
@@ -1,4 +1,47 @@
 package com.loadingking.loading_king.core.sector.application;
 
+import com.loadingking.loading_king.core.sector.domain.Sector;
+import com.loadingking.loading_king.core.sector.domain.SectorRepository;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
 public class SectorService {
+
+    private final SectorRepository sectorRepository;
+
+    public SectorService(SectorRepository sectorRepository) {
+        this.sectorRepository = sectorRepository;
+    }
+
+    /**
+     * 주어진 섹터 ID 목록에서 위치를 포함하는 섹터 찾기
+     * @param sectorIds 섹터 ID 목록
+     * @param location 확인 할 위치
+     * @return 포함하는 섹터가 있으면 Optional에 담아 반환, 없으면 빈 Optional 반환
+     */
+    @Transactional(readOnly = true)
+    public Optional<Sector> findContainingSector(List<Long> sectorIds, Point location) {
+        List<Sector> sectors = sectorRepository.findAllById(sectorIds);
+
+        return sectors.stream()
+                .filter(sector -> sector.contains(location))
+                .findFirst();
+    }
+
+    /**
+     * 주어진 섹터 ID 목록에 해당하는 모든 섹터를 조회
+     * @param sectorIds 섹터 ID 목록
+     * @return 해당하는 섹터들의 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<Sector> getAllSectorsByIds(List<Long> sectorIds) {
+        return sectorRepository.findAllById(sectorIds);
+    }
+
 }

--- a/src/main/java/com/loadingking/loading_king/core/sector/domain/Sector.java
+++ b/src/main/java/com/loadingking/loading_king/core/sector/domain/Sector.java
@@ -1,4 +1,105 @@
 package com.loadingking.loading_king.core.sector.domain;
 
+import jakarta.persistence.*;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+/**
+ * 섹터 도메인 클래스
+ */
+@Entity
+@Table(name = "sectors")
 public class Sector {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "sector_id")
+    private Long id;          // 식별자
+
+    @Column(name = "sector_name", nullable = false)
+    private String sectorName; // 섹터 이름 (예: 잠실본동)
+
+    @Column(name = "boundary", nullable = false)
+    private Polygon boundary; // 행정동 경계
+
+    @Column(name = "center", nullable = false)
+    private Point centerCoordinate; // 중심 좌표
+
+    protected Sector() {}
+
+    /**
+     * 섹터 생성
+     * @param sectorName 섹터 이름
+     * @param boundary 경계 다각형
+     * @param centerCoordinate 중심 좌표
+     * @return
+     */
+    public static Sector create(String sectorName, Polygon boundary, Point centerCoordinate) {
+        return new Builder()
+                .sectorName(sectorName)
+                .boundary(boundary)
+                .centerCoordinate(centerCoordinate)
+                .build();
+    }
+
+    /**
+     * 주어진 위치가 섹터의 경계 내에 포함되는지 여부를 확인
+     * @param location 확인할 위치
+     * @return 경계 내에 포함되면 true, 그렇지 않으면 false
+     * @throws IllegalArgumentException location이 null인 경우 발생
+     */
+    public boolean contains(Point location) {
+        if(location == null) {
+            throw new IllegalArgumentException("location cannot be null");
+        }
+        
+        return this.boundary.contains(location);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSectorName() {
+        return sectorName;
+    }
+
+    public Polygon getBoundary() {
+        return boundary;
+    }
+
+    public Point getCenterCoordinate() {
+        return centerCoordinate;
+    }
+
+    private Sector(Builder builder) {
+        this.sectorName = builder.sectorName;
+        this.boundary = builder.boundary;
+        this.centerCoordinate = builder.centerCoordinate;
+    }
+
+    public static class Builder {
+        private String sectorName;
+        private Polygon boundary;
+        private Point centerCoordinate;
+
+        public Builder sectorName(String sectorName) {
+            this.sectorName = sectorName;
+            return this;
+        }
+
+        public Builder boundary(Polygon boundary) {
+            this.boundary = boundary;
+            return this;
+        }
+
+        public Builder centerCoordinate(Point centerCoordinate) {
+            this.centerCoordinate = centerCoordinate;
+            return this;
+        }
+
+        public Sector build() {
+            return new Sector(this);
+        }
+    }
 }

--- a/src/main/java/com/loadingking/loading_king/core/sector/domain/SectorRepository.java
+++ b/src/main/java/com/loadingking/loading_king/core/sector/domain/SectorRepository.java
@@ -1,0 +1,9 @@
+package com.loadingking.loading_king.core.sector.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SectorRepository extends JpaRepository<Sector,Long> {
+
+}

--- a/src/main/java/com/loadingking/loading_king/core/sector/dto/SectorAssignmentResponse.java
+++ b/src/main/java/com/loadingking/loading_king/core/sector/dto/SectorAssignmentResponse.java
@@ -1,0 +1,15 @@
+package com.loadingking.loading_king.core.sector.dto;
+
+/**
+ * 섹터 할당 응답 DTO
+ * @param isAssigned 포함 여부
+ * @param sectorName 섹터 이름
+ * @param displayColor 식별 색상
+ * @param message 사용자 안내 메시지
+ */
+public record SectorAssignmentResponse(
+        boolean isAssigned,
+        String sectorName,
+        String displayColor,
+        String message
+) {}

--- a/src/test/java/com/loadingking/loading_king/core/sector/application/SectorServiceTest.java
+++ b/src/test/java/com/loadingking/loading_king/core/sector/application/SectorServiceTest.java
@@ -1,0 +1,73 @@
+package com.loadingking.loading_king.core.sector.application;
+
+import com.loadingking.loading_king.core.sector.domain.Sector;
+import com.loadingking.loading_king.core.sector.domain.SectorRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SectorService 테스트")
+class SectorServiceTest {
+
+    @Mock
+    private SectorRepository sectorRepository;
+
+    @InjectMocks
+    private SectorService sectorService;
+
+    private final GeometryFactory factory = new GeometryFactory();
+
+    @Test
+    @DisplayName("좌표를 포함하는 섹터가 목록에 있으면 해당 섹터를 반환한다")
+    void shouldReturnSector_WhenLocationIsInside() {
+        // Given
+        Long id1 = 1L;
+        Long id2 = 2L;
+        Point targetLocation = factory.createPoint(new Coordinate(0.5, 0.5));
+
+        // Mock 데이터 생성 (Reflection이나 Builder를 통해 ID를 세팅했다고 가정)
+        Sector s1 = createSectorWithId(id1, 10, 10, 11, 11); // 좌표 미포함 섹터
+        Sector s2 = createSectorWithId(id2, 0, 0, 1, 1);     // 좌표 포함 섹터
+
+        // Repository 동작 정의: 어떤 ID 리스트를 넣든 우리가 만든 섹터 리스트 반환
+        given(sectorRepository.findAllById(anyList())).willReturn(List.of(s1, s2));
+
+        // When
+        Optional<Sector> result = sectorService.findContainingSector(List.of(id1, id2), targetLocation);
+
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(id2, result.get().getId()); // s2가 반환되어야 함
+        verify(sectorRepository, times(1)).findAllById(anyList()); // 리포지토리가 1번 호출되었나 확인
+    }
+
+    // ID 주입이 포함된 헬퍼 메서드
+    private Sector createSectorWithId(Long id, double x1, double y1, double x2, double y2) {
+        Polygon p = factory.createPolygon(new Coordinate[]{
+                new Coordinate(x1, y1), new Coordinate(x2, y1),
+                new Coordinate(x2, y2), new Coordinate(x1, y2), new Coordinate(x1, y1)
+        });
+        Sector s = Sector.create("dd", p, factory.createPoint(new Coordinate((x1 + x2) / 2, (y1 + y2) / 2)));
+
+        ReflectionTestUtils.setField(s, "id", id);
+        return s;
+    }
+}

--- a/src/test/java/com/loadingking/loading_king/core/sector/domain/SectorRepositoryTest.java
+++ b/src/test/java/com/loadingking/loading_king/core/sector/domain/SectorRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.loadingking.loading_king.core.sector.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@DisplayName("SectorRepository 테스트")
+class SectorRepositoryTest {
+
+    @Autowired
+    private SectorRepository sectorRepository;
+
+    private final GeometryFactory factory = new GeometryFactory();
+
+    @Test
+    @DisplayName("ID 목록이 주어졌을 때 해당하는 모든 섹터를 조회한다")
+    void shouldFindAllByIds() {
+        // Given
+        Polygon polygon = factory.createPolygon(new Coordinate[]{
+                new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0)
+        });
+
+        Sector sector1 = Sector.create("섹터1", polygon, factory.createPoint(new Coordinate(0.5, 0.5)));
+        Sector sector2 = Sector.create("섹터2", polygon, factory.createPoint(new Coordinate(0.7, 0.7)));
+
+        sectorRepository.save(sector1);
+        sectorRepository.save(sector2);
+
+        // When
+        List<Sector> foundSectors = sectorRepository.findAllById(List.of(sector1.getId(), sector2.getId()));
+
+        // Then
+        assertEquals(2, foundSectors.size());
+        assertTrue(foundSectors.stream().anyMatch(s -> s.getSectorName().equals("섹터1")));
+        assertTrue(foundSectors.stream().anyMatch(s -> s.getSectorName().equals("섹터2")));
+    }
+}

--- a/src/test/java/com/loadingking/loading_king/core/sector/domain/SectorTest.java
+++ b/src/test/java/com/loadingking/loading_king/core/sector/domain/SectorTest.java
@@ -1,0 +1,87 @@
+package com.loadingking.loading_king.core.sector.domain;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Sector Domain 테스트")
+class SectorTest {
+
+    private final GeometryFactory factory = new GeometryFactory();
+    private Sector sector;
+
+    private Point insidePoint;
+    private Point outsidePoint;
+    private Point onBoundaryPoint;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 공통으로 사용할 다각형(Boundary) 설정
+        Polygon boundary = factory.createPolygon(new Coordinate[] {
+                new Coordinate(126.97, 37.56),
+                new Coordinate(127.00, 37.56),
+                new Coordinate(127.00, 37.58),
+                new Coordinate(126.97, 37.58),
+                new Coordinate(126.97, 37.56)
+        });
+
+        // 2. 공통 Sector 객체 생성
+        sector = Sector.create("Test Sector", boundary, factory.createPoint(new Coordinate(126.985, 37.57)));
+
+        // 3. 테스트 케이스별 좌표 데이터 준비
+        insidePoint = factory.createPoint(new Coordinate(126.98, 37.57));
+        outsidePoint = factory.createPoint(new Coordinate(126.98, 37.60));
+        onBoundaryPoint = factory.createPoint(new Coordinate(126.97, 37.57));
+    }
+
+    @Test
+    @DisplayName("TC-SECTOR-1: 배송 물품의 좌표가 현재의 경계 내부에 포함이 되는 경우 True를 반환한다")
+    void shouldReturnTrue_WhenItemPointInsideBoundary() {
+        assertTrue(sector.contains(insidePoint), "배송 물품 좌표가 섹터 경계 내이면 True를 반환해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("TC-SECTOR-2: location이 NULL 일 경우 IllegalArgumentException을 던져야 한다")
+    void shouldThrowIllegalArgumentException_WhenLocationIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> sector.contains(null));
+    }
+
+    @Test
+    @DisplayName("TC-SECTOR-3: 배송 물품의 좌표가 현재의 경계 외부에 있는 경우 False를 반환한다")
+    void shouldReturnFalse_WhenItemPointOutsideBoundary() {
+        assertFalse(sector.contains(outsidePoint), "배송 물품 좌표가 섹터 경계 외부이면 False를 반환해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("TC-SECTOR-4: 주어진 좌표가 섹터 경계선 위에 있을 때 false를 반환해야 한다")
+    void shouldReturnFalse_WhenPointIsOnBoundaryLine() {
+        assertFalse(sector.contains(onBoundaryPoint), "섹터 경계선에 있는 좌표는 포함되지 않은 것으로 간주되어 False를 반환해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("TC-SECTOR-5: 복잡한 형태의 다각형에서도 contains가 올바르게 작동해야 한다")
+    void shouldWorkCorrectly_WhenComplexPolygon() {
+        // Given
+        Polygon complexPolygon = factory.createPolygon(new Coordinate[] {
+                new Coordinate(126.97, 37.56),
+                new Coordinate(127.00, 37.56),
+                new Coordinate(127.01, 37.57),
+                new Coordinate(127.00, 37.58),
+                new Coordinate(126.98, 37.58),
+                new Coordinate(126.97, 37.57),
+                new Coordinate(126.97, 37.56)
+        });
+
+        // When, Then
+        assertTrue(sector.contains(insidePoint), "복잡한 다각형 내부의 좌표는 포함되어야 합니다.");
+        assertFalse(sector.contains(outsidePoint), "복잡한 다각형 외부의 좌표는 포함되지 않아야 합니다.");
+    }
+}


### PR DESCRIPTION
## Summary
- Sector 관련 로직 구현

## Related Issue

## Changes
- Dependencies 추가
  - h2: 테스트용 데이터베이스
  - h2gis: h2 데이터베이스 기반 공간 연산 관련 라이브러리
- Sector, DeliveryJob 도메인 추가
  - Sector는 Repository, Service, Controller(스켈리톤 코드) 구현 -> Controller 제외 테스트 코드 구현 
  - DeliveryJob은 도메인 Repository, Service구현(logistics 부분) -> 테스트 코드 미구현

## Discussion Topic
- DeliveryJob 부분 관련 driverId 추가 논의
  - UC-02의 3번 - 시스템은 변환된 좌표가 기사의 설정된 섹터 중 어디에 포함되는지 공간 연산으로 확인
     * 실패시 "구역 외 지역(미배정)" 경고를 띄워 기사가 별도로 분류하게 한다
     * 부분에서 미배정된 부분을 기사가 선택하게 하려면 기사 기반 미배정된 섹터를 조회하게 해야 함

## Checklist
- [x] 로컬 테스트 완료
- [ ] lint 통과(로컬)
- [x] 리뷰어 요청(최소 2명), 라벨/스코프 지정
- [x] 브랜치 최신화(rebase) 및 충돌 없음